### PR TITLE
Add "Esc" key functionality to close search dialog

### DIFF
--- a/src/components/search/CommandPalette.svelte
+++ b/src/components/search/CommandPalette.svelte
@@ -104,6 +104,11 @@
 
       event.preventDefault();
     }
+
+    // close on escape
+    if (event.key === "Escape" && $showSearch) {
+      $showSearch = false;
+    }
   }}
 />
 


### PR DESCRIPTION
Builds on `on:keydown` event listener for the `Escape` key to allow users to close the search dialog. This enhances usability by providing a common keyboard shortcut to dismiss the dialog.